### PR TITLE
fixbug in adbcj-mysql and adbcj-h2

### DIFF
--- a/api/.classpath
+++ b/api/.classpath
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/api/.project
+++ b/api/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>adbcj-api</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/api/.settings/org.eclipse.core.resources.prefs
+++ b/api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/test/java=UTF-8
+encoding//src/test/resources=UTF-8
+encoding/<project>=UTF-8

--- a/api/.settings/org.eclipse.jdt.core.prefs
+++ b/api/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.8

--- a/api/.settings/org.eclipse.m2e.core.prefs
+++ b/api/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/api/src/main/java/org/adbcj/CloseMode.java
+++ b/api/src/main/java/org/adbcj/CloseMode.java
@@ -12,5 +12,11 @@ public enum CloseMode {
      * Cancels all pending requests and the closes the resource.
      * No new requests / commands will be accepted.
      */
-    CANCEL_PENDING_OPERATIONS;
+    CANCEL_PENDING_OPERATIONS,
+	/**
+     * Cancels all pending requests and then closes the resource forcibly even if using connection pool.
+     * No new requests / commands will be accepted.
+     * @since 2017-09-02 little-pan
+     */
+    CLOSE_FORCIBLY;
 }

--- a/api/src/main/java/org/adbcj/support/LoginCredentials.java
+++ b/api/src/main/java/org/adbcj/support/LoginCredentials.java
@@ -64,9 +64,10 @@ public final class LoginCredentials {
 
     @Override
     public String toString() {
+    	// Mask password for security issue sine 2017-10-15 little-pan
         return "LoginCredentials{" +
                 "userName='" + userName + '\'' +
-                ", password='" + password + '\'' +
+                ", password='" + "******" + '\'' +
                 ", database='" + database + '\'' +
                 '}';
     }

--- a/h2/.classpath
+++ b/h2/.classpath
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/h2/.project
+++ b/h2/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>h2-async-driver</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/h2/.settings/org.eclipse.core.resources.prefs
+++ b/h2/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding/<project>=UTF-8

--- a/h2/.settings/org.eclipse.jdt.core.prefs
+++ b/h2/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.8

--- a/h2/.settings/org.eclipse.m2e.core.prefs
+++ b/h2/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/h2/src/main/java/org/adbcj/h2/Encoder.java
+++ b/h2/src/main/java/org/adbcj/h2/Encoder.java
@@ -2,6 +2,7 @@ package org.adbcj.h2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
 import org.adbcj.h2.packets.ClientToServerPacket;
@@ -16,10 +17,16 @@ class Encoder extends MessageToByteEncoder<ClientToServerPacket> {
 
     @Override
     public void encode(ChannelHandlerContext ctx, ClientToServerPacket request, ByteBuf buffer) throws Exception {
+    	final int wi = buffer.writerIndex();
         ByteBufOutputStream out = new ByteBufOutputStream(buffer);
         DataOutputStream dataOutputStream = new DataOutputStream(out);
         request.writeToStream(dataOutputStream);
         dataOutputStream.close();
         out.close();
+        // debug packet sent since 2017-09-19 pzp
+        if(logger.isDebugEnabled()) {
+        	final int length = buffer.writerIndex() - wi;
+        	logger.debug("Packet sent: request - {}\n{}", request, ByteBufUtil.prettyHexDump(buffer, wi, length));
+    	}
     }
 }

--- a/h2/src/main/java/org/adbcj/h2/decoding/Constants.java
+++ b/h2/src/main/java/org/adbcj/h2/decoding/Constants.java
@@ -5,4 +5,17 @@ public final class Constants {
      * The TCP protocol version number 11.
      */
     public static final int TCP_PROTOCOL_VERSION_12 = 12;
+    
+    /**
+     * The TCP protocol version number 14.
+     */
+    public static final int TCP_PROTOCOL_VERSION_14 = 14;
+    
+    /**
+     * The TCP protocl version number 15.
+     * @since 2017-09-24 little-pan
+     */
+    public static final int TCP_PROTOCOL_VERSION_15 = 15;
+    
+    
 }

--- a/h2/src/main/java/org/adbcj/h2/decoding/Decoder.java
+++ b/h2/src/main/java/org/adbcj/h2/decoding/Decoder.java
@@ -2,11 +2,14 @@ package org.adbcj.h2.decoding;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import org.adbcj.Connection;
 import org.adbcj.DbCallback;
 import org.adbcj.h2.H2Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.DataInputStream;
 import java.io.InputStream;
@@ -14,6 +17,8 @@ import java.util.List;
 
 
 public class Decoder extends ByteToMessageDecoder {
+	private static final Logger logger = LoggerFactory.getLogger(Decoder.class);
+	
     private static Object DecodedToken = new Object();
     private DecoderState currentState;
     private H2Connection connection;
@@ -30,6 +35,11 @@ public class Decoder extends ByteToMessageDecoder {
 
     @Override
     public void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
+    	// debug received packet since 2017-09-19 pzp
+    	if(logger.isDebugEnabled()) {
+    		final int ri = buffer.readerIndex(), length = buffer.readableBytes();
+    		logger.debug("Packet recv: \n{}", ByteBufUtil.prettyHexDump(buffer, ri, length));
+    	}
         InputStream in = new ByteBufInputStream(buffer);
         in.mark(Integer.MAX_VALUE);
         try {

--- a/h2/src/main/java/org/adbcj/h2/decoding/FirstServerHandshake.java
+++ b/h2/src/main/java/org/adbcj/h2/decoding/FirstServerHandshake.java
@@ -9,12 +9,16 @@ import org.adbcj.h2.packets.AnnounceClientSession;
 import org.adbcj.support.SizeConstants;
 import org.adbcj.h2.protocol.StatusCodes;
 import io.netty.channel.Channel;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
 
 import java.io.DataInputStream;
 import java.io.IOException;
 
 
 class FirstServerHandshake extends StatusReadingDecoder {
+	final static AttributeKey<Integer> ATTR_CLI_VER = AttributeKey.valueOf("h2.clientVersion");
+	
     private final DbCallback<Connection> callback;
     private final H2Connection connection;
 
@@ -37,6 +41,10 @@ class FirstServerHandshake extends StatusReadingDecoder {
             throw new DbException("This version only supports version " + Constants.TCP_PROTOCOL_VERSION_12
                     + ", but server wants " + clientVersion);
         }
+        // cache client-version in channel for following usage.
+        // @since 2017-09-24 little-pan
+        final Attribute<Integer> attr = channel.attr(ATTR_CLI_VER);
+        attr.set(clientVersion);
         channel.writeAndFlush(new AnnounceClientSession(connection.getSessionId()));
         return ResultAndState.newState(new SessionIdReceived(callback, connection, entry));
     }
@@ -58,7 +66,14 @@ class SessionIdReceived extends StatusReadingDecoder {
     @Override
     protected ResultAndState processFurther(DataInputStream input, Channel channel, int status) throws IOException {
         StatusCodes.STATUS_OK.expectStatusOrThrow(status);
-        ResultOrWait<Boolean> autoCommit = IoUtils.tryReadNextBoolean(input, ResultOrWait.Start);
+        // response auto-commit only after version 15.
+        // @since 2017-09-24 little-pan
+        final ResultOrWait<Boolean> autoCommit;
+        if(channel.attr(FirstServerHandshake.ATTR_CLI_VER).get() >= Constants.TCP_PROTOCOL_VERSION_15) {
+        	autoCommit = IoUtils.tryReadNextBoolean(input, ResultOrWait.Start);
+        }else {
+        	autoCommit = ResultOrWait.result(Boolean.TRUE);
+        }
         if(autoCommit.couldReadResult){
             connection.forceQueRequest(connection.requestCreator().createGetAutoIdStatement(callback, entry));
             connection.forceQueRequest(connection.requestCreator().createCommitStatement(callback, entry));

--- a/jdbc/.classpath
+++ b/jdbc/.classpath
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/jdbc/.project
+++ b/jdbc/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>adbcj-jdbc</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/jdbc/.settings/org.eclipse.core.resources.prefs
+++ b/jdbc/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding/<project>=UTF-8

--- a/jdbc/.settings/org.eclipse.jdt.core.prefs
+++ b/jdbc/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.8

--- a/jdbc/.settings/org.eclipse.m2e.core.prefs
+++ b/jdbc/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/mysql/.classpath
+++ b/mysql/.classpath
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/mysql/.project
+++ b/mysql/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>mysql-async-driver</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/mysql/.settings/org.eclipse.core.resources.prefs
+++ b/mysql/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/mysql/.settings/org.eclipse.jdt.core.prefs
+++ b/mysql/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.8

--- a/mysql/.settings/org.eclipse.m2e.core.prefs
+++ b/mysql/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/mysql/Changes.log
+++ b/mysql/Changes.log
@@ -1,0 +1,29 @@
+Changes log
+
+@author little-pan
+@since 2017-09-02
+
+2017-10-15 little-pan
+  Add - log4j.properties in src/main/resources.
+  Change - Mask password for security issue in LoginCredentials.toString().
+
+2017-09-24 little-pan
+  Fixbug - read auto-commit response in client version 12 in H2 FirstServerHandshake.processFurther().
+  No auto-commit response below client version 15 in H2!
+  Add - Tracing or debug H2 protocol in Encoder.encode() and Decoder.decode(). 
+
+2017-09-02 little-pan
+  Fixbug - Sand-boxing the DbCallback for protecting ADBCJ kernel from being destroyed when the exception
+occurs in user callback code(DbCallback.complete()).
+
+2017-09-01 little-pan
+  Fixbug - Lost the last char in IoUtils.readNullTerminatedString().
+  Add - mark()/reset() functions in BoundedInputStream for handling error in Connecting.parse().
+  Add - CLOSE_FORCIBLY close mode for supporting close connection forcibly.
+  Fixbug - Can't handle the error response in init handshake phase(Connecting.parse()). Add the connection 
+close function when the error occurs.
+  Fixbug - Can't handle Pre-4.1 or init handshake error packet in ResponseStart.decodeErrorResponse().
+Moving the decodeErrorResponse() into DecoderState for handling init handshake error such as
+'Too many connections' in Connecting。
+  Change - Error format(ERROR %d (%s): %s) adjustment as mysql command reporting in ErrorResponse.toException().
+  Add - Tracing or debug MySQL protocol in MySqlClientDecoder.doDecode().

--- a/mysql/src/main/java/org/adbcj/mysql/MysqlConnectionManager.java
+++ b/mysql/src/main/java/org/adbcj/mysql/MysqlConnectionManager.java
@@ -195,7 +195,12 @@ class Decoder extends ByteToMessageDecoder {
 
     @Override
     public void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
-        InputStream in = new ByteBufInputStream(buffer);
+    	// debug buffer since 2017-10-15 little-pan
+    	final boolean debug = log.isDebugEnabled();
+    	if(debug) {
+    		log.debug("Decoded buffer#{}: {}", buffer.hashCode(), buffer);
+    	}
+        final InputStream in = new ByteBufInputStream(buffer);
         try {
             Object obj = decoder.decode(in, ctx.channel(), false);
             if (log.isDebugEnabled() && null != obj) {

--- a/mysql/src/main/java/org/adbcj/mysql/codec/BoundedInputStream.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/BoundedInputStream.java
@@ -8,6 +8,8 @@ public class BoundedInputStream extends InputStream {
 
     private final InputStream in;
     private int remaining;
+    // Support mark()/reset 2017-09-01 little-pan
+    private int position, mark = -1;
 
     public BoundedInputStream(InputStream in, int length) {
         this.in = in;
@@ -19,6 +21,7 @@ public class BoundedInputStream extends InputStream {
         int i = in.read();
         if (i >= 0) {
             remaining --;
+            position ++;
         }
         if (remaining < 0) {
             throw new IllegalStateException("Buffer overrun");
@@ -30,6 +33,7 @@ public class BoundedInputStream extends InputStream {
     public int read(byte[] b, int off, int len) throws IOException {
         int i = in.read(b, off, len);
         remaining -= i;
+        position  += i;
         if (remaining < 0) {
             throw new IllegalStateException("Read too many bytes");
         }
@@ -40,6 +44,7 @@ public class BoundedInputStream extends InputStream {
     public long skip(long n) throws IOException {
         long i = in.skip(n);
         remaining -= i;
+        position  += i;
         if (remaining < 0) {
             throw new IllegalStateException("Read too many bytes");
         }
@@ -61,10 +66,39 @@ public class BoundedInputStream extends InputStream {
         while (count < length) {
             int read = in.read(buffer, off + count, length - count);
             remaining -= read;
+            position  += read;
             if (read < 0)
                 throw new EOFException("Expected to read " + length + ". But stream ended at " + count);
             count += read;
         }
+    }
+    
+    /**
+     * @since 2017-09-01 little-pan
+     */
+    @Override
+    public void mark(final int readlimit) {
+    	in.mark(readlimit);
+    	mark = position;
+    }
+    
+    /**
+     * @since 2017-09-01 little-pan
+     */
+    @Override
+    public void reset() throws IOException {
+    	in.reset();
+    	remaining+= (position - mark);
+    	position  = mark;
+    	mark      = -1;
+    }
+    
+    /**
+     * @since 2017-09-01 little-pan
+     */
+    @Override
+    public boolean markSupported() {
+    	return in.markSupported();
     }
 
 }

--- a/mysql/src/main/java/org/adbcj/mysql/codec/IoUtils.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/IoUtils.java
@@ -220,10 +220,14 @@ public final class IoUtils {
         if(in.getRemaining()<=0){
             return "";
         }
-        int c = in.read();
-        while (c > 0 && in.getRemaining()>0) {
-            out.write(c);
-            c = in.read();
+        for (int c = in.read(); c > 0; c = in.read()) {
+        	out.write(c);
+            // fixbug: lost the last char issue. The remaining decision should be placed here 
+            //and not in for-condition!
+            // @since 2017-09-01 little-pan
+            if(in.getRemaining() <= 0) {
+            	break;
+            }
         }
         return new String(out.toByteArray(), charset);
 

--- a/mysql/src/main/java/org/adbcj/mysql/codec/decoding/DecoderState.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/decoding/DecoderState.java
@@ -1,9 +1,12 @@
 package org.adbcj.mysql.codec.decoding;
 
+import org.adbcj.DbCallback;
+import org.adbcj.DbException;
 import org.adbcj.mysql.codec.BoundedInputStream;
 import org.adbcj.mysql.codec.IoUtils;
 import org.adbcj.mysql.codec.ServerStatus;
 import org.adbcj.mysql.codec.packets.EofResponse;
+import org.adbcj.mysql.codec.packets.ErrorResponse;
 import org.adbcj.mysql.codec.packets.ServerPacket;
 import io.netty.channel.Channel;
 import org.slf4j.Logger;
@@ -11,14 +14,17 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
-
 public abstract class DecoderState {
+	
     protected static final Logger logger = LoggerFactory.getLogger(DecoderState.class);
-    public static final int RESPONSE_EOF = 0xfe;
-
-
+    
+    public static final int RESPONSE_ERROR = 0xff;
+    public static final int RESPONSE_EOF   = 0xfe;
+    public static final int RESPONSE_OK    = 0x00;
 
     public abstract ResultAndState parse(int length,
                                          int packetNumber,
@@ -28,11 +34,85 @@ public abstract class DecoderState {
     public ResultAndState result( DecoderState newState,ServerPacket result){
         return new ResultAndState(newState,result);
     }
+    
     protected EofResponse decodeEofResponse(InputStream in, int length, int packetNumber, EofResponse.Type type) throws IOException {
         int warnings = IoUtils.readUnsignedShort(in);
         Set<ServerStatus> serverStatus = IoUtils.readEnumSetShort(in, ServerStatus.class);
 
         return new EofResponse(length, packetNumber, warnings, serverStatus, type);
     }
+    
+    public static ErrorResponse decodeErrorResponse(BoundedInputStream in, int length, int packetNumber) throws IOException {
+    	// The Payload of an ERR Packet
+    	//Type	      Name	           Description
+    	//-----------------------------------------------------------
+    	//int<1>	  header	       0xFF ERR packet header
+    	//int<2>	  error_code	   error-code
+    	//if capabilities & CLIENT_PROTOCOL_41 {
+    	//string[1]	  sql_state_marker # marker of the SQL state
+    	//string[5]	  sql_state	       SQL state
+    	//}
+    	//string<EOF> error_message	   human readable error message
+        final int errorNumber = IoUtils.readUnsignedShort(in);
+        final boolean hasMarker;
+        in.mark(Integer.MAX_VALUE);
+        try {
+        	hasMarker = ('#' == in.read());
+        } finally {
+        	in.reset();
+        }
+        final Charset CHARSET = StandardCharsets.UTF_8;
+        final String sqlState, message;
+        if (hasMarker) {
+        	in.read(); // Throw away sqlstate marker
+        	// fixbug: sql_state string[5] as null-terming-string.
+            // @since 2017-08-27 little-pan
+            //String sqlState = IoUtils.readNullTerminatedString(in, CHARSET);
+        	sqlState = IoUtils.readFixedLengthString(in, 5, CHARSET);
+        	message  = IoUtils.readNullTerminatedString(in, CHARSET);
+        } else {
+        	// Prev-4.1's message, still can be output 
+        	//in newer versions(e.g 'Too many connections')
+        	// @since 2017-09-01 little-pan
+        	sqlState = "HY000";
+        	message  = IoUtils.readFixedLengthString(in, length - 3, CHARSET);
+        }
+        return new ErrorResponse(length, packetNumber, errorNumber, sqlState, message);
+    }
+    
+    /**
+     * Sand-boxing the DbCallback for protecting ADBCJ kernel from being destroyed when the exception
+	 *occurs in user DbCallback.onComplete() code.
+     * 
+     * @param cb the database callback
+     * @return the sand-boxed callback
+     * 
+     * @since 2017-09-02 little-pan
+     */
+    public static <T> DbCallback<T> sandboxCb(final DbCallback<T> cb){
+    	if(cb.getClass() == SandboxDbCallback.class) {
+    		return cb;
+    	}
+    	return (new SandboxDbCallback<T>(cb));
+    }
+    
+    static class SandboxDbCallback<T> implements DbCallback<T> {
+    	final DbCallback<T> callback;
+    	
+    	SandboxDbCallback(final DbCallback<T> callback){
+    		this.callback = callback;
+    	}
+
+		@Override
+		public void onComplete(final T result, final DbException failure) {
+			try {
+				callback.onComplete(result, failure);
+    		}catch(final Throwable cause) {
+    			logger.warn("Uncaught exception in DbCallback", cause);
+    		}
+		}
+    	
+    }
+    
 }
 

--- a/mysql/src/main/java/org/adbcj/mysql/codec/decoding/ExpectOK.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/decoding/ExpectOK.java
@@ -13,7 +13,7 @@ public class ExpectOK<T> extends ResponseStart {
 
     public ExpectOK(MySqlConnection connection, DbCallback<T> callback, StackTraceElement[] entry) {
         super(connection);
-        this.callback = callback;
+        this.callback = sandboxCb(callback);
         this.entry = entry;
     }
 

--- a/mysql/src/main/java/org/adbcj/mysql/codec/decoding/ExpectPreparQuery.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/decoding/ExpectPreparQuery.java
@@ -23,7 +23,7 @@ public class ExpectPreparQuery extends DecoderState {
             DbCallback<MySqlPreparedStatement> callback,
             StackTraceElement[] entry) {
         super();
-        this.callback = callback;
+        this.callback = sandboxCb(callback);
         this.entry = entry;
         this.connection = connection;
     }

--- a/mysql/src/main/java/org/adbcj/mysql/codec/decoding/ExpectQueryResult.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/decoding/ExpectQueryResult.java
@@ -31,7 +31,7 @@ public class ExpectQueryResult<T> extends ResponseStart {
         this.decodingType = decodingType;
         this.eventHandler = eventHandler;
         this.accumulator = accumulator;
-        this.callback = callback;
+        this.callback = sandboxCb(callback);
         this.entry = entry;
     }
 

--- a/mysql/src/main/java/org/adbcj/mysql/codec/decoding/FieldDecodingState.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/decoding/FieldDecodingState.java
@@ -39,10 +39,9 @@ public class FieldDecodingState<T> extends DecoderState {
             StackTraceElement[] entry,
             DbException failure) {
         this.decodingType = decodingType;
-
         this.expectedAmountOfFields = expectedAmountOfFields;
         this.fields = fields;
-        this.callback = callback;
+        this.callback = sandboxCb(callback);
         this.entry = entry;
         this.connection = connection;
         this.eventHandler = eventHandler;

--- a/mysql/src/main/java/org/adbcj/mysql/codec/decoding/FieldEof.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/decoding/FieldEof.java
@@ -34,7 +34,7 @@ class FieldEof<T> extends DecoderState {
             DbException failure) {
         this.decodingType = decodingType;
         this.fields = fields;
-        this.callback = callback;
+        this.callback = sandboxCb(callback);
         this.connection = connection;
         this.eventHandler = eventHandler;
         this.accumulator = accumulator;

--- a/mysql/src/main/java/org/adbcj/mysql/codec/decoding/FinishLogin.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/decoding/FinishLogin.java
@@ -13,7 +13,7 @@ public class FinishLogin extends ResponseStart {
 
     public FinishLogin(DbCallback<Connection> connected, StackTraceElement[] entry, MySqlConnection connectionToBuild) {
         super(connectionToBuild);
-        this.connected = connected;
+        this.connected = sandboxCb(connected);
         this.entry = entry;
     }
 

--- a/mysql/src/main/java/org/adbcj/mysql/codec/decoding/FinishPrepareStatement.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/decoding/FinishPrepareStatement.java
@@ -26,7 +26,7 @@ abstract class FinishPrepareStatement extends DecoderState {
             PreparedStatementToBuild statement,
             DbCallback<MySqlPreparedStatement> callback) {
         this.statement = statement;
-        this.callback = callback;
+        this.callback  = sandboxCb(callback);
         this.connection = connection;
     }
 

--- a/mysql/src/main/java/org/adbcj/mysql/codec/decoding/ResponseStart.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/decoding/ResponseStart.java
@@ -1,20 +1,16 @@
 package org.adbcj.mysql.codec.decoding;
 
-import org.adbcj.mysql.codec.BoundedInputStream;
-import org.adbcj.mysql.codec.IoUtils;
+import java.io.IOException;
+
 import org.adbcj.mysql.MySqlConnection;
+import org.adbcj.mysql.codec.BoundedInputStream;
 import org.adbcj.mysql.codec.packets.ErrorResponse;
 import org.adbcj.mysql.codec.packets.OkResponse;
+
 import io.netty.channel.Channel;
 
-import java.io.EOFException;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-
 public abstract class ResponseStart extends DecoderState {
-    public static final int RESPONSE_OK = 0x00;
-    public static final int RESPONSE_ERROR = 0xff;
+	
     protected final MySqlConnection connection;
 
     protected ResponseStart(MySqlConnection connection) {
@@ -53,16 +49,5 @@ public abstract class ResponseStart extends DecoderState {
         throw new IllegalStateException("This state: "+this+" does not expect a result which can be interpreted as " +
                 "query result");
     }
-
-
-    public static ErrorResponse decodeErrorResponse(BoundedInputStream in, int length, int packetNumber) throws IOException {
-        int errorNumber = IoUtils.readUnsignedShort(in);
-        // Throw away sqlstate marker
-        if(in.read()<0){
-            throw new EOFException("Unexpected EOF. Expected to read 1 more byte");
-        }
-        String sqlState = IoUtils.readNullTerminatedString(in, StandardCharsets.UTF_8);
-        String message = IoUtils.readNullTerminatedString(in, StandardCharsets.UTF_8);
-        return new ErrorResponse(length, packetNumber, errorNumber, sqlState, message);
-    }
+    
 }

--- a/mysql/src/main/java/org/adbcj/mysql/codec/decoding/Row.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/decoding/Row.java
@@ -40,9 +40,9 @@ public class Row<T> extends DecoderState {
         this.connection = connection;
         this.eventHandler = eventHandler;
         this.accumulator = accumulator;
-        this.callback = callback;
-        this.entry = entry;
-        this.failure = failure;
+        this.callback = sandboxCb(callback);
+        this.entry    = entry;
+        this.failure  = failure;
     }
 
     @Override

--- a/mysql/src/main/java/org/adbcj/mysql/codec/packets/ErrorResponse.java
+++ b/mysql/src/main/java/org/adbcj/mysql/codec/packets/ErrorResponse.java
@@ -46,7 +46,15 @@ public class ErrorResponse extends ServerPacket {
 	}
 
     public MysqlException toException(StackTraceElement[] entry){
-        return new MysqlException(getSqlState() + " " + getMessage(), null, entry);
+    	// Error format adjustment as mysql command reporting.
+    	// @since 2017-09-01 little-pan
+        return new MysqlException(toString(), null, entry);
+    }
+    
+    @Override
+    public String toString() {
+    	final String format= "ERROR %d (%s): %s";
+    	return (String.format(format, errorNumber, sqlState, message));
     }
 
 }

--- a/mysql/src/main/resources/log4j.properties
+++ b/mysql/src/main/resources/log4j.properties
@@ -1,0 +1,26 @@
+# config log4j since 2017-10-15 little-pan
+log4j.rootLogger = DEBUG,STDOUT,FILE
+
+# variables
+PATTERN = %-d{yyyy-MM-dd HH:mm:ss.SSS}[%5p][%t] %.36c.%M(): %L - %m%n
+LOGDIR  = logs
+
+# Appender STDOUT 
+log4j.appender.STDOUT = org.apache.log4j.ConsoleAppender 
+log4j.appender.STDOUT.layout = org.apache.log4j.PatternLayout 
+log4j.appender.STDOUT.layout.ConversionPattern = ${PATTERN}
+log4j.appender.STDOUT.Threshold = DEBUG 
+log4j.appender.STDOUT.ImmediateFlush = TRUE 
+log4j.appender.STDOUT.Target = System.out
+
+# Appender FILE
+log4j.appender.FILE = org.apache.log4j.RollingFileAppender 
+log4j.appender.FILE.layout = org.apache.log4j.PatternLayout 
+log4j.appender.FILE.layout.ConversionPattern = ${PATTERN}
+log4j.appender.FILE.Threshold = DEBUG 
+log4j.appender.FILE.ImmediateFlush = TRUE 
+log4j.appender.FILE.Append= TRUE 
+log4j.appender.FILE.File= ${LOGDIR}/adbcj.log 
+log4j.appender.FILE.MaxFileSize = 1MB 
+log4j.appender.FILE.MaxBackupIndex = 10 
+log4j.appender.FILE.Encoding = UTF-8

--- a/mysql/src/test/java/org/adbcj/h2/connect/ConnectTest.java
+++ b/mysql/src/test/java/org/adbcj/h2/connect/ConnectTest.java
@@ -1,0 +1,78 @@
+package org.adbcj.h2.connect;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.adbcj.Connection;
+import org.adbcj.ConnectionManager;
+import org.adbcj.ConnectionManagerProvider;
+import org.adbcj.StandardProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConnectTest {
+	final static Logger log = LoggerFactory.getLogger(ConnectTest.class);
+
+	public static void main(String[] args) throws InterruptedException {
+		final int n = 1;
+		// h2 url schema - adbcj:h2://host:port/db, no "tcp:" after "h2:"
+		final String url = "adbcj:h2://localhost:9092/test;DB_CLOSE_DELAY=-1";
+		final String username = "sa", password = "";
+		final long tms = System.currentTimeMillis();
+		final AtomicInteger success = new AtomicInteger(0);
+		final CountDownLatch cnlat  = new CountDownLatch(n);
+		final CountDownLatch colat  = new CountDownLatch(1);
+		ConnectionManager cm = null;
+		try {
+			final Map<String, String> props = new HashMap<>();
+			props.put(StandardProperties.CONNECTION_POOL_ENABLE, "false");
+			cm = ConnectionManagerProvider
+				.createConnectionManager(url, username, password, props);
+			for(int i = 0; i < n; ++i) {
+				log.debug("connecting-{} pending", i);
+				CompletableFuture<Connection> cf = cm.connect();
+				cf.whenComplete((c, e) -> {
+					cnlat.countDown();
+					if(e != null) {
+						log.warn("<<< connect error", e);
+					}
+				}).thenCompose((c) -> {
+					log.debug("connection is open? {}", c.isOpen());
+					return c.close();
+				}).thenRun(() -> {
+					success.incrementAndGet();
+					log.debug("<<< connection closed");
+				});
+//				cm.connect((c, e) -> {
+//					cnlat.countDown();
+//					if(e == null) {
+//						throw new RuntimeException("error test");
+//						//return;
+//					}
+//					log.warn("connct error: {}", e);
+//				});
+			}
+			cnlat.await();
+		}catch(final Throwable cause) {
+			log.warn("fatal error", cause);
+		}finally {
+			if(cm != null) {
+				cm.close().whenComplete((r, e)->{
+					if(e == null) {
+						log.info("close completed");
+					}else {
+						log.warn("close error", e);
+					}
+					colat.countDown();
+				});
+			}
+			colat.await();
+			log.info("time: {}ms, ttl: {}, success: {}", 
+				(System.currentTimeMillis()-tms), n, success.get());
+		}
+	}
+
+}

--- a/mysql/src/test/java/org/adbcj/mysql/connect/ConnectTest.java
+++ b/mysql/src/test/java/org/adbcj/mysql/connect/ConnectTest.java
@@ -1,0 +1,74 @@
+package org.adbcj.mysql.connect;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.adbcj.Connection;
+import org.adbcj.ConnectionManager;
+import org.adbcj.ConnectionManagerProvider;
+import org.adbcj.StandardProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConnectTest {
+	final static Logger log = LoggerFactory.getLogger(ConnectTest.class);
+
+	public static void main(String[] args) throws InterruptedException {
+		final int n = 10; // 10000 - test 'Too many connections' error handle
+		final String url = "adbcj:mysql://localhost:3306/test";
+		final String username = "test", password = "123456";
+		final long tms = System.currentTimeMillis();
+		final AtomicInteger success = new AtomicInteger(0);
+		final CountDownLatch cnlat  = new CountDownLatch(n);
+		final CountDownLatch colat  = new CountDownLatch(1);
+		ConnectionManager cm = null;
+		try {
+			final Map<String, String> props = new HashMap<>();
+			props.put(StandardProperties.CONNECTION_POOL_ENABLE, "false");
+			cm = ConnectionManagerProvider
+				.createConnectionManager(url, username, password, props);
+			for(int i = 0; i < n; ++i) {
+				CompletableFuture<Connection> cf = cm.connect();
+				cf.whenComplete((c, e) -> {
+					cnlat.countDown();
+					if(e != null) {
+						log.warn("<<< connect error", e);
+					}
+				}).thenCompose((c) -> {
+					log.debug("connection is open? {}", c.isOpen());
+					return c.close();
+				}).thenRun(() -> {
+					success.incrementAndGet();
+					log.debug("<<< connection closed");
+				});
+				cm.connect((c, e) -> {
+					cnlat.countDown();
+					if(e == null) {
+						// user callback exception
+						throw new RuntimeException("error test");
+					}
+					log.warn("connct error: {}", e);
+				});
+			}
+			cnlat.await();
+		}finally {
+			if(cm != null) {
+				cm.close().whenComplete((r, e)->{
+					if(e == null) {
+						log.info("close completed");
+					}else {
+						log.warn("close error", e);
+					}
+					colat.countDown();
+				});
+			}
+			colat.await();
+			log.info("time: {}ms, ttl: {}, success: {}", 
+				(System.currentTimeMillis()-tms), n, success.get());
+		}
+	}
+
+}

--- a/tck/.classpath
+++ b/tck/.classpath
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/tck/.project
+++ b/tck/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>adbcj-tck</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/tck/.settings/org.eclipse.core.resources.prefs
+++ b/tck/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+encoding//src/test/java=UTF-8
+encoding//src/test/resources=UTF-8
+encoding/<project>=UTF-8

--- a/tck/.settings/org.eclipse.jdt.core.prefs
+++ b/tck/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.8

--- a/tck/.settings/org.eclipse.m2e.core.prefs
+++ b/tck/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1


### PR DESCRIPTION
2017-10-15 little-pan
  Add - log4j.properties in src/main/resources.
  Change - Mask password for security issue in
LoginCredentials.toString().

2017-09-24 little-pan
  Fixbug - read auto-commit response in client version 12 in H2
FirstServerHandshake.processFurther().
  No auto-commit response below client version 15 in H2!
  Add - Tracing or debug H2 protocol in Encoder.encode() and
Decoder.decode(). 

2017-09-02 little-pan
  Fixbug - Sand-boxing the DbCallback for protecting ADBCJ kernel from
being destroyed when the exception
occurs in user callback code(DbCallback.complete()).

2017-09-01 little-pan
  Fixbug - Lost the last char in IoUtils.readNullTerminatedString().
  Add - mark()/reset() functions in BoundedInputStream for handling
error in Connecting.parse().
  Add - CLOSE_FORCIBLY close mode for supporting close connection
forcibly.
  Fixbug - Can't handle the error response in init handshake
phase(Connecting.parse()). Add the connection 
close function when the error occurs.
  Fixbug - Can't handle Pre-4.1 or init handshake error packet in
ResponseStart.decodeErrorResponse().
Moving the decodeErrorResponse() into DecoderState for handling init
handshake error such as
'Too many connections' in Connecting。
  Change - Error format(ERROR %d (%s): %s) adjustment as mysql command
reporting in ErrorResponse.toException().
  Add - Tracing or debug MySQL protocol in
MySqlClientDecoder.doDecode().